### PR TITLE
Add viewing key retrieval

### DIFF
--- a/crates/webz-common/src/error.rs
+++ b/crates/webz-common/src/error.rs
@@ -4,6 +4,8 @@ use wasm_bindgen::JsValue;
 pub enum Error {
     #[error("Invalid network string given: {0}")]
     InvalidNetwork(String),
+    #[error("Invalid amount: {0}")]
+    InvalidAmount(#[from] zcash_primitives::transaction::components::amount::BalanceError),
 }
 
 impl From<Error> for JsValue {

--- a/crates/webz-keys/src/keys.rs
+++ b/crates/webz-keys/src/keys.rs
@@ -1,6 +1,3 @@
-// Copyright 2024 ChainSafe Systems
-// SPDX-License-Identifier: Apache-2.0, MIT
-
 use std::str::FromStr;
 use wasm_bindgen::prelude::*;
 
@@ -35,6 +32,27 @@ impl UnifiedSpendingKey {
             inner: zcash_keys::keys::UnifiedSpendingKey::from_seed(
                 &network,
                 &seed,
+                AccountId::try_from(hd_index)?,
+            )?,
+        })
+    }
+
+    /// Construct a UnifiedSpendingKey from a seed
+    ///
+    /// # Arguments
+    ///
+    /// * `network` - Must be either "main" or "test"
+    /// * `seed` - A string representing the seed
+    /// * `hd_index` - [ZIP32](https://zips.z.cash/zip-0032) hierarchical deterministic index of the account
+    ///
+    pub fn from_seed(network: &str, seed: &str, hd_index: u32) -> Result<UnifiedSpendingKey, Error> {
+        let network = Network::from_str(network)?;
+        let mnemonic = Mnemonic::<English>::from_phrase(seed).map_err(|_| Error::InvalidSeedPhrase)?;
+        let seed_bytes = mnemonic.to_seed("");
+        Ok(Self {
+            inner: zcash_keys::keys::UnifiedSpendingKey::from_seed(
+                &network,
+                &seed_bytes,
                 AccountId::try_from(hd_index)?,
             )?,
         })

--- a/crates/webz-wallet/src/wallet.rs
+++ b/crates/webz-wallet/src/wallet.rs
@@ -374,6 +374,36 @@ where
         tracing::info!("Sending transactions");
         self.send_authorized_transactions(&txids).await
     }
+
+    /// Get the viewing key for a given account. This is returned as a string in canonical encoding
+    ///
+    /// # Arguments
+    ///
+    /// * `account_id` - The ID of the account to get the viewing key for
+    ///
+    pub async fn get_viewing_key(&self, account_id: AccountId) -> Result<String, Error> {
+        let db = self.db.read().await;
+        if let Some(ufvk) = db.get_account(account_id)?.map(|a| a.viewing_key().clone()) {
+            Ok(ufvk.encode(&self.network))
+        } else {
+            Err(Error::AccountNotFound(account_id.into()))
+        }
+    }
+
+    /// Get the spending key for a given account. This is returned as a string in canonical encoding
+    ///
+    /// # Arguments
+    ///
+    /// * `account_id` - The ID of the account to get the spending key for
+    ///
+    pub async fn get_spending_key(&self, account_id: AccountId) -> Result<String, Error> {
+        let db = self.db.read().await;
+        if let Some(usk) = db.get_account(account_id)?.map(|a| a.spending_key().clone()) {
+            Ok(usk.encode(&self.network))
+        } else {
+            Err(Error::AccountNotFound(account_id.into()))
+        }
+    }
 }
 
 pub(crate) fn usk_from_seed_str(

--- a/packages/snap/src/rpc/getViewingKey.ts
+++ b/packages/snap/src/rpc/getViewingKey.ts
@@ -12,7 +12,7 @@ export async function getViewingKey(
     const seed = await getSeed();
 
     // Generate the UnifiedSpendingKey and obtain the Viewing Key
-    let spendingKey = new UnifiedSpendingKey(network, seed, accountIndex);
+    let spendingKey = UnifiedSpendingKey.from_seed(network, seed, accountIndex);
     let viewingKey = spendingKey.to_unified_full_viewing_key();
 
     return viewingKey.encode(network);


### PR DESCRIPTION
Add new error variant and methods to handle invalid amounts and keys.

* **Error Handling**
  - Add `InvalidAmount` variant to `Error` enum in `crates/webz-common/src/error.rs`.
  - Implement `From<zcash_primitives::transaction::components::amount::BalanceError>` for `Error`.

* **Key Management**
  - Add `UnifiedSpendingKey::from_seed` method in `crates/webz-keys/src/keys.rs` to create a spending key from a seed.
  - Add `UnifiedFullViewingKey::encode` method in `crates/webz-keys/src/keys.rs` to encode the viewing key as a string.
  - Add `WebWallet::get_viewing_key` and `WebWallet::get_spending_key` methods in `crates/webz-wallet/src/bindgen/wallet.rs` to retrieve keys for an account.
  - Add `Wallet::get_viewing_key` and `Wallet::get_spending_key` methods in `crates/webz-wallet/src/wallet.rs` to retrieve keys for an account.

* **Function Updates**
  - Update `getViewingKey` function in `packages/snap/src/rpc/getViewingKey.ts` to use the new `UnifiedSpendingKey::from_seed` and `UnifiedFullViewingKey::encode` methods.

